### PR TITLE
debug undefined index 'message'

### DIFF
--- a/src/Provider/Zoom.php
+++ b/src/Provider/Zoom.php
@@ -140,8 +140,16 @@ class Zoom extends AbstractProvider
     protected function checkResponse(ResponseInterface $response, $data)
     {
         if ($response->getStatusCode() >= 400) {
+            if (!empty($data['reason'])) {
+                $reason = $data['reason'];
+            } elseif (!empty ($data['message'])) {
+                $reason = $data['message'];
+            } else {
+                $reason = $response->getReasonPhrase();
+            }
+
             throw new IdentityProviderException(
-                $data['message'] ?: $response->getReasonPhrase(),
+                $reason,
                 $response->getStatusCode(),
                 $response
             );

--- a/src/Provider/Zoom.php
+++ b/src/Provider/Zoom.php
@@ -142,7 +142,7 @@ class Zoom extends AbstractProvider
         if ($response->getStatusCode() >= 400) {
             if (!empty($data['reason'])) {
                 $reason = $data['reason'];
-            } elseif (!empty ($data['message'])) {
+            } elseif (!empty($data['message'])) {
                 $reason = $data['message'];
             } else {
                 $reason = $response->getReasonPhrase();


### PR DESCRIPTION
I tested this with an invalid `client_id` and received a "Undefined Index 'message'" error. `$this->getReasonPhrase()` also returned simply "Unauthorized". I found the `reason` index to provide the most detailed message of `Invalid client_id or client_secret`.